### PR TITLE
Add a preset connection for the MongoDB extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "mdb.presetConnections": [
+        {
+            "name": "Local MongoDB Database",
+            "connectionString": "mongodb://admin:mongodb@localhost:27017"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a preset connection for easier access to the local database from the MongoDB extension.

<img width="376" alt="Screenshot 2025-05-22 at 23 05 02" src="https://github.com/user-attachments/assets/eb9379e0-3bcc-411c-b465-f0f08ac22210" />
