### PR TITLE
Update image so we can use a local Atlas cluster both locally and in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
     "name": "Jupyter Notebook with MongoDB",
+    "features": {
+        "ghcr.io/devcontainers/features/python:1": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {}
+    },
     "dockerComposeFile": "docker-compose.yml",
     "service": "lab-runner",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   lab-runner:
-    image: mcr.microsoft.com/devcontainers/universal:2
+    image: mcr.microsoft.com/devcontainers/base:ubuntu
     volumes:
       - ../..:/workspaces:cached
     depends_on:


### PR DESCRIPTION
The current image, `mcr.microsoft.com/devcontainers/universal:2`, works in Codespaces but not with arm/Apple Silicon, so for users who are using say, Apple Silicon Macs, they would have to setup a remote Atlas cluster to run this locally.

Switching to a `mcr.microsoft.com/devcontainers/base:ubuntu`, which has both x86 and arm support, makes it such that both Windows and Apple Silicon users can run the notebooks locally using a local Atlas cluster without having to create an Atlas account and remote Atlas cluster, reducing the friction for running it locally as well.