### PR TITLE
Change to use gemini-2.5-pro

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -121,7 +121,7 @@ def get_llm(provider: str):
         )
     elif provider == "google":
         return ChatGoogleGenerativeAI(
-            model="gemini-1.5-pro",
+            model="gemini-2.5-pro",
             temperature=0,
         )
     elif provider == "microsoft":


### PR DESCRIPTION
Fix issue regarding gemini-1.5-pro not found. When using `gemini-1.5-pro` , I faced this error

<img width="720" height="201" alt="image" src="https://github.com/user-attachments/assets/2e79b14c-23f2-4c5f-975d-3bac1a8fb852" />
