### PR TITLE
save_procedure response must be parsed into json format before json.load

### DIFF
--- a/labs/agent-memory-lab.ipynb
+++ b/labs/agent-memory-lab.ipynb
@@ -602,7 +602,7 @@
     "            \"messages\": messages,\n",
     "            \"output_config\": {\"format\": {\"type\": \"json_schema\", \"schema\": json_schema}}\n",
     "        }}\n",
-    "    )\n",
+    "    ).json()\n",
     "    \n",
     "    # Parse the LLM response\n",
     "    procedure = json.loads(response[\"content\"][0][\"text\"])\n",

--- a/solutions/agent-memory-lab.ipynb
+++ b/solutions/agent-memory-lab.ipynb
@@ -602,7 +602,7 @@
     "            \"messages\": messages,\n",
     "            \"output_config\": {\"format\": {\"type\": \"json_schema\", \"schema\": json_schema}}\n",
     "        }}\n",
-    "    )\n",
+    "    ).json()\n",
     "    \n",
     "    # Parse the LLM response\n",
     "    procedure = json.loads(response[\"content\"][0][\"text\"])\n",


### PR DESCRIPTION
Whenever save_procedure is triggered, it throws an exception 'Response' object is not subscriptable.

We need to parse the response object into json first.